### PR TITLE
Classification element pipe and uppercase directive

### DIFF
--- a/src/app/features/home/product-list/product-list.component.html
+++ b/src/app/features/home/product-list/product-list.component.html
@@ -26,3 +26,9 @@
   </mat-form-field>
 </form>
 <input type="text" glSearchDirective>
+
+<section style="margin: 24px 0;">
+  <h2>Ingresa tu nombre</h2>
+  <p>El sistema automáticamente pondrá tu nombre en mayúsculas.</p>
+  <input type="text" uppercaseTextDirective>
+</section>

--- a/src/app/features/home/product-list/product-list.component.html
+++ b/src/app/features/home/product-list/product-list.component.html
@@ -13,7 +13,7 @@
   </ng-container>
   <ng-container matColumnDef="symbol">
     <th mat-header-cell *matHeaderCellDef>Symbol</th>
-    <td mat-cell *matCellDef="let element">{{ element | indexTable:dataSource }}</td>
+    <td mat-cell *matCellDef="let element">{{ element.symbol | classificationChemicalElement }}</td>
   </ng-container>
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>

--- a/src/app/shared/directives/uppercase-text.directive.spec.ts
+++ b/src/app/shared/directives/uppercase-text.directive.spec.ts
@@ -1,0 +1,8 @@
+import { UppercaseTextDirective } from './uppercase-text.directive';
+
+describe('UppercaseTextDirective', () => {
+  it('should create an instance', () => {
+    const directive = new UppercaseTextDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/src/app/shared/directives/uppercase-text.directive.ts
+++ b/src/app/shared/directives/uppercase-text.directive.ts
@@ -1,0 +1,19 @@
+import { Directive, ElementRef, HostListener } from '@angular/core';
+
+@Directive({
+  selector: '[uppercaseTextDirective]'
+})
+export class UppercaseTextDirective {
+
+  constructor(private el: ElementRef) { }
+
+  @HostListener('keydown', ['$event']) onKeyDown(event: Event): void {
+    const alphabet = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'];
+    const letterInput = (event as KeyboardEvent).key;
+    if (alphabet.includes(letterInput)) {
+      event.preventDefault();
+      this.el.nativeElement.value += letterInput.toUpperCase();
+    }
+  }
+
+}

--- a/src/app/shared/pipes/classification-chemical-element.pipe.spec.ts
+++ b/src/app/shared/pipes/classification-chemical-element.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { ClassificationChemicalElementPipe } from './classification-chemical-element.pipe';
+
+describe('ClassificationChemicalElementPipe', () => {
+  it('create an instance', () => {
+    const pipe = new ClassificationChemicalElementPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/shared/pipes/classification-chemical-element.pipe.ts
+++ b/src/app/shared/pipes/classification-chemical-element.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'classificationChemicalElement'
+})
+export class ClassificationChemicalElementPipe implements PipeTransform {
+
+  transform(value: unknown): unknown {
+    const foo = 'bar';
+    return foo;
+  }
+
+}

--- a/src/app/shared/pipes/classification-chemical-element.pipe.ts
+++ b/src/app/shared/pipes/classification-chemical-element.pipe.ts
@@ -5,9 +5,64 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class ClassificationChemicalElementPipe implements PipeTransform {
 
-  transform(value: unknown): unknown {
-    const foo = 'bar';
-    return foo;
+  private classificationChemicalElements = [
+    {
+      category: 'Alcalinos',
+      elements: ['li', 'na', 'k', 'rb', 'cs', 'fr']
+    },
+    {
+      category: 'Alcalinoterreos',
+      elements: ['be', 'mg', 'ca', 'sr', 'ba', 'ra']
+    },
+    {
+      category: 'Metales de transición',
+      elements: ['sc', 'ti', 'v', 'cr', 'mn', 'fe', 'co', 'ni', 'cu', 'zn', 'y', 'zr', 'nb', 'mo', 'tc', 'ru', 'rh', 'pd', 'ag', 'cd', 'la', 'hf', 'ta', 'w', 're', 'os', 'ir', 'pt', 'au', 'hg', 'ac', 'rf', 'db', 'sg', 'bh', 'hs', 'mt', 'ds', 'rg', 'cn', 'fl', 'lv', 'la', 'ce', 'pr', 'nd', 'pm', 'sm', 'eu', 'gd', 'tb', 'dy', 'ho', 'er', 'tm', 'yb', 'lu']
+    },
+    {
+      category: 'Otros metales',
+      elements: ['b', 'al', 'ga', 'in', 'tl', 'ce', 'pb', 'bi']
+    },
+    {
+      category: 'Metaloides',
+      elements: ['si', 'ge', 'sn', 'sb', 'te', 'po']
+    },
+    {
+      category: 'No metales',
+      elements: ['h', 'c', 'n', 'o', 'f', 'p', 's', 'se', 'as', 'br', 'i', 'at']
+    },
+    {
+      category: 'Gases nobles',
+      elements: ['he', 'ne', 'ar', 'kr', 'xe', 'rn']
+    },
+    {
+      category: 'Lantánidos',
+      elements: ['la', 'ce', 'pr', 'nd', 'pm', 'sm', 'eu', 'gd', 'tb', 'dy', 'ho', 'er', 'tm', 'yb', 'lu']
+    },
+    {
+      category: 'Actínidos',
+      elements: ['ac', 'th', 'pa', 'u', 'np', 'pu', 'am', 'cm', 'bk', 'cf', 'es', 'fm', 'md', 'no', 'lr']
+    }
+  ]
+
+  transform(value: string): string {
+    if(typeof value === 'string')
+      return this.getClassificationChemicalElement(value);
+    return 'Sin clasificar';
+  }
+
+  /**
+   * Categoría del elemento químico, por ejemplo Alcalinos, Alcalinoterreos, etc.
+   * @param symbol Simbolo del elemento químico, por ejemplo H, He, C, N, etc.
+   * @returns
+   */
+  getClassificationChemicalElement(symbol: string): string {
+    let classification = 'Sin clasificar';
+    this.classificationChemicalElements.forEach(element => {
+      if (element.elements.includes(symbol.toLowerCase())) {
+        classification = element.category;
+      }
+    });
+    return classification;
   }
 
 }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -6,8 +6,9 @@ import { MaterialModule } from '../material/material.module';
 import { ChangeNamePipe } from './pipes/change-name.pipe';
 import { DirectiveSearchDirective } from './directives/directive-search.directive';
 import { IndexTablePipe } from './pipes/index-table.pipe';
+import { ClassificationChemicalElementPipe } from './pipes/classification-chemical-element.pipe';
 
-const COMPONENTS = [FooterComponent,HeaderComponent,ChangeNamePipe,IndexTablePipe,DirectiveSearchDirective,IndexTablePipe]
+const COMPONENTS = [FooterComponent,HeaderComponent,ChangeNamePipe,IndexTablePipe,DirectiveSearchDirective,IndexTablePipe, ClassificationChemicalElementPipe]
 
 @NgModule({
   declarations: [...COMPONENTS],

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -7,8 +7,9 @@ import { ChangeNamePipe } from './pipes/change-name.pipe';
 import { DirectiveSearchDirective } from './directives/directive-search.directive';
 import { IndexTablePipe } from './pipes/index-table.pipe';
 import { ClassificationChemicalElementPipe } from './pipes/classification-chemical-element.pipe';
+import { UppercaseTextDirective } from './directives/uppercase-text.directive';
 
-const COMPONENTS = [FooterComponent,HeaderComponent,ChangeNamePipe,IndexTablePipe,DirectiveSearchDirective,IndexTablePipe, ClassificationChemicalElementPipe]
+const COMPONENTS = [FooterComponent,HeaderComponent,ChangeNamePipe,IndexTablePipe,DirectiveSearchDirective,IndexTablePipe, ClassificationChemicalElementPipe, UppercaseTextDirective]
 
 @NgModule({
   declarations: [...COMPONENTS],


### PR DESCRIPTION
CLASSIFICATION CHEMICAL ELEMENT PIPE
Toma el símbolo del elemento químico y retorna su categoría correspondiente dentro de la tabla periódica. Ejemplos:
    H --> No metales
    Li --> Alcalinos
    Xe --> Gases nobles
    . . .

UPPERCASE DIRECTIVE
Toma el carácter de entrada y retorna su correspondiente símbolo en mayúscula. De esta forma el usuario va a escribir dentro de un campo de texto en sólo mayúsculas obligatoriamente. Ejemplos:
    a --> A
    m --> M
    h --> H
    . . .